### PR TITLE
fix: disable escape on text given to Vue

### DIFF
--- a/src/BillForm.vue
+++ b/src/BillForm.vue
@@ -700,7 +700,7 @@ export default {
 				paymentmodeChar = cospend.paymentModes[this.myBill.paymentmode].icon + ' '
 			}
 			const whatFormatted = paymentmodeChar + categoryChar + this.myBill.what.replace(/https?:\/\/[^\s]+/gi, '')
-			return t('cospend', 'Bill : {what}', { what: whatFormatted })
+			return t('cospend', 'Bill : {what}', { what: whatFormatted }, undefined, { escape: false })
 		},
 		billDateObject() {
 			return moment.unix(this.myBill.timestamp).toDate()


### PR DESCRIPTION
### Before:

![image](https://user-images.githubusercontent.com/47195730/118881626-e0b7c300-b925-11eb-9fa9-df54e6d9b3d4.png)


### After:

![image](https://user-images.githubusercontent.com/47195730/118881491-bbc35000-b925-11eb-92a7-226e9db867e0.png)
