### PR TITLE
Add PHP 8.1 and PHP 8.2 test support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
         databases: ['sqlite', 'mysql', 'pgsql']
         server-versions: ['stable22', 'stable23', 'stable24', 'master']
         exclude:


### PR DESCRIPTION
PHP 8.1 was released last year and PHP 8.2 will be released at the end of the year, but the first alpha version is already available.

Nextcloud did the same a few days earlier, see https://github.com/nextcloud/server/blob/master/.github/workflows/lint.yml