### PR TITLE
Move bill support

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -137,6 +137,7 @@ return [
 		['name' => 'page#webEditMember', 'url' => '/projects/{projectid}/members/{memberid}', 'verb' => 'PUT'],
 		['name' => 'page#webGetBills', 'url' => '/projects/{projectid}/bills', 'verb' => 'GET'],
 		['name' => 'page#webAddBill', 'url' => '/projects/{projectid}/bills', 'verb' => 'POST'],
+		['name' => 'page#webMoveBill', 'url' => '/projects/{projectid}/bills/{billid}/move', 'verb' => 'POST'],
 		['name' => 'page#webRepeatBill', 'url' => '/projects/{projectid}/bills/{billid}/repeat', 'verb' => 'GET'],
 		['name' => 'page#webEditBill', 'url' => '/projects/{projectid}/bills/{billid}', 'verb' => 'PUT'],
 		['name' => 'page#webEditBills', 'url' => '/projects/{projectid}/bills', 'verb' => 'PUT'],

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -694,7 +694,7 @@ class PageController extends ApiController {
 	/**
 	 * @NoAdminRequired
 	 */
-	public function webMoveBill (string $projectid, int $billid, string $toProjectId): DataResponse {
+	public function webMoveBill(string $projectid, int $billid, string $toProjectId): DataResponse {
 		// ensure the user has permission to access both projects
 		$userAccessLevel = $this->projectService->getUserMaxAccessLevel($this->userId, $projectid);
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -693,6 +693,34 @@ class PageController extends ApiController {
 
 	/**
 	 * @NoAdminRequired
+	 */
+	public function webMoveBill (string $projectid, int $billid, string $toProjectId): DataResponse {
+		// ensure the user has permission to access both projects
+		$userAccessLevel = $this->projectService->getUserMaxAccessLevel ($this->userId, $projectid);
+
+		if ($userAccessLevel < Application::ACCESS_LEVELS ['participant']) {
+			return new DataResponse (['message' => $this->trans->t ('You are not allowed to edit this bill')], 403);
+		}
+
+		$userAccessLevel = $this->projectService->getUserMaxAccessLevel ($this->userId, $toProjectId);
+
+		if ($userAccessLevel < Application::ACCESS_LEVELS ['participant']) {
+			return new DataResponse (['message' => $this->trans->t ('You are not allowed to access the destination project')], 403);
+		}
+
+		// update the bill information
+		$result = $this->projectService->moveBill ($projectid, $billid, $toProjectId);
+
+		if (!isset ($result ['inserted_id'])) {
+			return new DataResponse ($result, 403);
+		}
+
+		// return a 200 response
+		return new DataResponse ($result ['inserted_id']);
+	}
+
+	/**
+	 * @NoAdminRequired
 	 *
 	 */
 	public function webRepeatBill(string $projectid, int $billid): DataResponse {

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -696,27 +696,27 @@ class PageController extends ApiController {
 	 */
 	public function webMoveBill (string $projectid, int $billid, string $toProjectId): DataResponse {
 		// ensure the user has permission to access both projects
-		$userAccessLevel = $this->projectService->getUserMaxAccessLevel ($this->userId, $projectid);
+		$userAccessLevel = $this->projectService->getUserMaxAccessLevel($this->userId, $projectid);
 
-		if ($userAccessLevel < Application::ACCESS_LEVELS ['participant']) {
-			return new DataResponse (['message' => $this->trans->t ('You are not allowed to edit this bill')], 403);
+		if ($userAccessLevel < Application::ACCESS_LEVELS['participant']) {
+			return new DataResponse(['message' => $this->trans->t('You are not allowed to edit this bill')], 403);
 		}
 
-		$userAccessLevel = $this->projectService->getUserMaxAccessLevel ($this->userId, $toProjectId);
+		$userAccessLevel = $this->projectService->getUserMaxAccessLevel($this->userId, $toProjectId);
 
-		if ($userAccessLevel < Application::ACCESS_LEVELS ['participant']) {
-			return new DataResponse (['message' => $this->trans->t ('You are not allowed to access the destination project')], 403);
+		if ($userAccessLevel < Application::ACCESS_LEVELS['participant']) {
+			return new DataResponse(['message' => $this->trans->t ('You are not allowed to access the destination project')], 403);
 		}
 
 		// update the bill information
-		$result = $this->projectService->moveBill ($projectid, $billid, $toProjectId);
+		$result = $this->projectService->moveBill($projectid, $billid, $toProjectId);
 
-		if (!isset ($result ['inserted_id'])) {
-			return new DataResponse ($result, 403);
+		if (!isset($result['inserted_id'])) {
+			return new DataResponse($result, 403);
 		}
 
 		// return a 200 response
-		return new DataResponse ($result ['inserted_id']);
+		return new DataResponse($result['inserted_id']);
 	}
 
 	/**

--- a/lib/Service/ProjectService.php
+++ b/lib/Service/ProjectService.php
@@ -1308,8 +1308,7 @@ class ProjectService {
 	public function deleteBill(string $projectid, int $billid, bool $force = false): array {
 		if ($force === false) {
 			$project = $this->getProjectInfo($projectid);
-			$deletionDisabled = $project['deletion_disabled'];
-			if ($deletionDisabled) {
+			if ($project['deletion_disabled']) {
 				return ['message' => 'Forbidden'];
 			}
 		}
@@ -3622,13 +3621,13 @@ class ProjectService {
 
 		if ($bill['paymentmodeid'] !== 0) {
 			$originPayment = array_filter($originPayments, static function ($val) use ($bill) {
-				return $val['id'] == $bill['paymentmodeid'];
+				return $val['id'] === $bill['paymentmodeid'];
 			});
 			$originPayment = array_shift($originPayment);
 
 			// find a payment mode with the same name
 			$paymentNameMatches = array_filter($destinationPayments, static function ($val) use ($originPayment) {
-				return $val['name'] == $originPayment['name'];
+				return $val['name'] === $originPayment['name'];
 			});
 
 			// no payment mode match, means new mode
@@ -3695,12 +3694,13 @@ class ProjectService {
 
 		// match owers too, these do not mind that much, the user will be able to modify the new invoice just after moving it
 		$newOwers = array_filter($destinationMembers, static function ($member) use ($bill) {
-			$matches = array_filter($bill ['owers'], static function ($oldMember) use ($member) {
-				return $oldMember ['name'] === $member ['name'];
+			$matches = array_filter($bill['owers'], static function ($oldMember) use ($member) {
+				return $oldMember['name'] === $member['name'];
 			});
 
-			if (count($matches) === 0)
+			if (count($matches) === 0) {
 				return false;
+			}
 
 			return true;
 		});
@@ -3709,7 +3709,7 @@ class ProjectService {
 		$newPaymentId = $this->copyBillPaymentMethodOver($projectid, $bill, $toProjectId);
 
 		$result = $this->addBill(
-			$toProjectId, null, $bill['what'], $newPayer ['id'],
+			$toProjectId, null, $bill['what'], $newPayer['id'],
 			implode(',', array_column($newOwers, 'id')), $bill['amount'], $bill['repeat'],
 			$bill['paymentmode'], $newPaymentId,
 			$newCategoryId, $bill['repeatallactive'], $bill['repeatuntil'],

--- a/src/App.vue
+++ b/src/App.vue
@@ -169,7 +169,7 @@ export default {
 		EmptyContent,
 		Button,
 		PlusIcon,
-		ProjectList
+		ProjectList,
 	},
 	mixins: [isMobile],
 	provide() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -59,11 +59,14 @@
 				@perso-bills-created="onPersoBillsCreated"
 				@duplicate-bill="onDuplicateBill"
 				@repeat-bill-now="onRepeatBillNow" />
-			<MoveToProjectList
-				v-else-if="mode === 'move'"
-				:bill="currentBill"
-				:project-id="currentProjectId"
-				@item-moved="onBillMoved" />
+			<Modal v-if="showMoveModal"
+				   size="normal"
+				   @close="showMoveModal = false">
+				<MoveToProjectList
+					:bill="billToMove"
+					:project-id="currentProjectId"
+					@item-moved="onBillMoved" />
+			</Modal>
 			<Statistics
 				v-else-if="mode === 'stats'"
 				:project-id="currentProjectId" />
@@ -137,6 +140,7 @@ import Content from '@nextcloud/vue/dist/Components/Content'
 import AppContent from '@nextcloud/vue/dist/Components/AppContent'
 import EmptyContent from '@nextcloud/vue/dist/Components/EmptyContent'
 import isMobile from '@nextcloud/vue/dist/Mixins/isMobile'
+import Modal from '@nextcloud/vue/dist/Components/Modal'
 
 import CospendNavigation from './components/CospendNavigation'
 import CospendSettingsDialog from './components/CospendSettingsDialog'
@@ -170,6 +174,7 @@ export default {
 		Button,
 		PlusIcon,
 		MoveToProjectList,
+		Modal
 	},
 	mixins: [isMobile],
 	provide() {
@@ -193,6 +198,8 @@ export default {
 			showSidebar: false,
 			activeSidebarTab: 'sharing',
 			selectedMemberId: null,
+			showMoveModal: false,
+			billToMove: null
 		}
 	},
 	computed: {
@@ -538,8 +545,8 @@ export default {
 			this.getBills(projectid)
 		},
 		onMoveBillClicked(bill) {
-			this.mode = 'move'
-			this.currentBill = bill
+			this.showMoveModal = true
+			this.billToMove = bill
 		},
 		onNewBillClicked(bill = null) {
 			// if a member is selected: deselect member and get full bill list
@@ -634,6 +641,8 @@ export default {
 			}
 		},
 		onBillMoved(newBillId, newProjectId) {
+			// close the modal
+			this.showMoveModal = false
 			// set the selected bill id
 			cospend.restoredCurrentBillId = newBillId
 			// select the project

--- a/src/App.vue
+++ b/src/App.vue
@@ -59,7 +59,7 @@
 				@perso-bills-created="onPersoBillsCreated"
 				@duplicate-bill="onDuplicateBill"
 				@repeat-bill-now="onRepeatBillNow" />
-			<ProjectList
+			<MoveToProjectList
 				v-else-if="mode === 'move'"
 				:bill="currentBill"
 				:project-id="currentProjectId"
@@ -145,7 +145,7 @@ import BillList from './BillList'
 import Statistics from './components/statistics/Statistics'
 import Settlement from './Settlement'
 import Sidebar from './components/Sidebar'
-import ProjectList from './components/ProjectList'
+import MoveToProjectList from './components/MoveToProjectList'
 
 import cospend from './state'
 import * as network from './network'
@@ -169,7 +169,7 @@ export default {
 		EmptyContent,
 		Button,
 		PlusIcon,
-		ProjectList,
+		MoveToProjectList,
 	},
 	mixins: [isMobile],
 	provide() {

--- a/src/BillList.vue
+++ b/src/BillList.vue
@@ -138,7 +138,8 @@
 				:edition-access="editionAccess"
 				:show-delete="!selectMode"
 				@clicked="onItemClicked"
-				@delete="onItemDeleted" />
+				@delete="onItemDeleted"
+				@move="onItemMove(bill)" />
 		</transition-group>
 		<InfiniteLoading v-if="!loading && bills.length > 30"
 			:identifier="projectId"
@@ -446,6 +447,9 @@ export default {
 			} else {
 				this.deleteBill(bill)
 			}
+		},
+		onItemMove(bill) {
+			this.$emit('move-bill-clicked', bill);
 		},
 		deleteBill(bill) {
 			network.deleteBill(this.projectId, bill).then((response) => {

--- a/src/BillList.vue
+++ b/src/BillList.vue
@@ -449,7 +449,7 @@ export default {
 			}
 		},
 		onItemMove(bill) {
-			this.$emit('move-bill-clicked', bill);
+			this.$emit('move-bill-clicked', bill)
 		},
 		deleteBill(bill) {
 			network.deleteBill(this.projectId, bill).then((response) => {

--- a/src/components/BillListItem.vue
+++ b/src/components/BillListItem.vue
@@ -38,7 +38,7 @@
 				</template>
 				{{ deleteIconTitle }}
 			</ActionButton>
-			<ActionButton
+			<ActionButton v-if="!timerOn"
 				:close-after-click="true"
 				@click="onMoveClick">
 				<template #icon>

--- a/src/components/BillListItem.vue
+++ b/src/components/BillListItem.vue
@@ -83,7 +83,7 @@ export default {
 		CheckboxBlankOutlineIcon,
 		CheckboxMarkedIcon,
 		ActionButton,
-		SwapHorizontalIcon
+		SwapHorizontalIcon,
 	},
 
 	props: {
@@ -236,7 +236,7 @@ export default {
 				: t('cospend', 'Delete this bill')
 		},
 		moveIconTitle() {
-			return t('cospend', 'Move bill');
+			return t('cospend', 'Move bill')
 		},
 		billDetails() {
 			return this.selected
@@ -253,7 +253,7 @@ export default {
 			this.$emit('clicked', this.bill)
 		},
 		onMoveClick(e) {
-			this.$emit('move');
+			this.$emit('move')
 		},
 		onDeleteClick(e) {
 			// stop timer

--- a/src/components/BillListItem.vue
+++ b/src/components/BillListItem.vue
@@ -38,6 +38,14 @@
 				</template>
 				{{ deleteIconTitle }}
 			</ActionButton>
+			<ActionButton
+				:close-after-click="true"
+				@click="onMoveClick">
+				<template #icon>
+					<SwapHorizontalIcon class="icon" :size="20" />
+				</template>
+				{{ moveIconTitle }}
+			</ActionButton>
 		</template>
 		<template #extra>
 			<div v-if="editionAccess && !showDelete" class="icon-selector">
@@ -59,6 +67,7 @@ import { generateUrl } from '@nextcloud/router'
 import moment from '@nextcloud/moment'
 import ListItem from '@nextcloud/vue/dist/Components/ListItem'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
+import SwapHorizontalIcon from 'vue-material-design-icons/SwapHorizontal'
 import ColoredAvatar from './ColoredAvatar'
 import { reload, Timer, getCategory, getPaymentMode, getSmartMemberName } from '../utils'
 
@@ -74,6 +83,7 @@ export default {
 		CheckboxBlankOutlineIcon,
 		CheckboxMarkedIcon,
 		ActionButton,
+		SwapHorizontalIcon
 	},
 
 	props: {
@@ -225,6 +235,9 @@ export default {
 				? t('cospend', 'Cancel')
 				: t('cospend', 'Delete this bill')
 		},
+		moveIconTitle() {
+			return t('cospend', 'Move bill');
+		},
 		billDetails() {
 			return this.selected
 				? this.billIndexText + ' ' + this.billDate
@@ -238,6 +251,9 @@ export default {
 	methods: {
 		onItemClick() {
 			this.$emit('clicked', this.bill)
+		},
+		onMoveClick(e) {
+			this.$emit('move');
 		},
 		onDeleteClick(e) {
 			// stop timer

--- a/src/components/MoveToProjectList.vue
+++ b/src/components/MoveToProjectList.vue
@@ -1,20 +1,22 @@
 <template>
-	<AppContentList ref="list">
-		<h3>
-			{{ t('cospend', 'Move bill "{bill}" to a different project:', {bill: bill.what}) }}
-		</h3>
-		<ListItem v-for="(project, index) in cospend.projects"
-			v-show="project.id !== projectId"
-			:key="project.id"
-			:title="project.name"
-			@click="onProjectClicked(project)" />
+	<div>
+		<h2>
+			{{ t('cospend', 'Move bill "{bill}" to a different project:', { bill: bill.what }) }}
+		</h2>
+		<ul>
+			<ListItem v-for="(project) in cospend.projects"
+				v-show="project.id !== projectId"
+				:key="project.id"
+				:title="project.name"
+				@click="onProjectClicked(project)" />
+		</ul>
 		<EmptyContent v-if="cospend.projects.length === 1 && cospend.projects[projectId]">
 			{{ t('cospend', 'Only one project available, which this bill already exists in') }}
 		</EmptyContent>
 		<EmptyContent v-else-if="cospend.projects.length === 0">
 			{{ t('cospend', 'No projects found') }}
 		</EmptyContent>
-	</AppContentList>
+	</div>
 </template>
 <script>
 import ListItem from '@nextcloud/vue/dist/Components/ListItem'

--- a/src/components/MoveToProjectList.vue
+++ b/src/components/MoveToProjectList.vue
@@ -24,7 +24,7 @@ import * as network from '../network'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 
 export default {
-	name: 'ProjectList',
+	name: 'MoveToProjectList',
 	components: {
 		ListItem,
 		AppContentList,

--- a/src/components/MoveToProjectList.vue
+++ b/src/components/MoveToProjectList.vue
@@ -4,14 +4,14 @@
 			{{ t('cospend', 'Move bill "{bill}" to a different project:', {bill: bill.what}) }}
 		</h3>
 		<ListItem v-for="(project, index) in cospend.projects"
-			v-show="project.id != projectId"
+			v-show="project.id !== projectId"
 			:key="project.id"
 			:title="project.name"
 			@click="onProjectClicked(project)" />
-		<EmptyContent v-if="cospend.projects.length == 1 && cospend.projects[projectId]">
+		<EmptyContent v-if="cospend.projects.length === 1 && cospend.projects[projectId]">
 			{{ t('cospend', 'Only one project available, which this bill already exists in') }}
 		</EmptyContent>
-		<EmptyContent v-else-if="cospend.projects.length == 0">
+		<EmptyContent v-else-if="cospend.projects.length === 0">
 			{{ t('cospend', 'No projects found') }}
 		</EmptyContent>
 	</AppContentList>

--- a/src/components/ProjectList.vue
+++ b/src/components/ProjectList.vue
@@ -1,0 +1,65 @@
+<template>
+	<AppContentList ref="list">
+		<h3>
+			{{ t('cospend', 'Move bill "{bill}" to a different project:', {bill: bill.what}) }}
+		</h3>
+		<ListItem v-for="(project, index) in cospend.projects"
+			:key="project.id"
+			:title="project.name"
+			v-show="project.id != projectId"
+			@click="onProjectClicked(project)">
+		</ListItem>
+		<EmptyContent v-if="cospend.projects.length == 1 && cospend.projects[projectId]">
+			{{ t('cospend', 'Only one project available, which this bill already exists in') }}
+		</EmptyContent>
+		<EmptyContent v-else-if="cospend.projects.length == 0">
+			{{ t('cospend', 'No projects found') }}
+		</EmptyContent>
+	</AppContentList>
+</template>
+<script>
+import ListItem from "@nextcloud/vue/dist/Components/ListItem";
+import AppContentList from "@nextcloud/vue/dist/Components/AppContentList";
+import cospend from '../state';
+import * as network from '../network';
+import {showError, showSuccess} from "@nextcloud/dialogs";
+
+export default {
+	name: 'ProjectList',
+	components: {
+		ListItem,
+		AppContentList
+	},
+	props: {
+		bill: {
+			type: Object,
+			required: true
+		},
+		projectId: {
+			type: String,
+			required: true,
+		},
+	},
+	created() {
+	},
+	data() {
+		return {
+			cospend
+		}
+	},
+	methods: {
+		onProjectClicked(project) {
+			network.moveBill(this.projectId, this.bill.id, project.id).then(res => {
+				showSuccess(t('cospend', 'Bill moved to "{project}" successfully', {project: project.name}))
+				this.$emit('item-moved', res.data, project.id)
+			}).catch(error => {
+				console.error(error)
+				showError(
+					t('cospend', 'Failed to move bill')
+					+ ': ' + (error.response?.data?.message || error.response?.request?.responseText)
+				)
+			})
+		},
+	},
+}
+</script>

--- a/src/components/ProjectList.vue
+++ b/src/components/ProjectList.vue
@@ -4,11 +4,10 @@
 			{{ t('cospend', 'Move bill "{bill}" to a different project:', {bill: bill.what}) }}
 		</h3>
 		<ListItem v-for="(project, index) in cospend.projects"
+			v-show="project.id != projectId"
 			:key="project.id"
 			:title="project.name"
-			v-show="project.id != projectId"
-			@click="onProjectClicked(project)">
-		</ListItem>
+			@click="onProjectClicked(project)" />
 		<EmptyContent v-if="cospend.projects.length == 1 && cospend.projects[projectId]">
 			{{ t('cospend', 'Only one project available, which this bill already exists in') }}
 		</EmptyContent>
@@ -18,39 +17,39 @@
 	</AppContentList>
 </template>
 <script>
-import ListItem from "@nextcloud/vue/dist/Components/ListItem";
-import AppContentList from "@nextcloud/vue/dist/Components/AppContentList";
-import cospend from '../state';
-import * as network from '../network';
-import {showError, showSuccess} from "@nextcloud/dialogs";
+import ListItem from '@nextcloud/vue/dist/Components/ListItem'
+import AppContentList from '@nextcloud/vue/dist/Components/AppContentList'
+import cospend from '../state'
+import * as network from '../network'
+import { showError, showSuccess } from '@nextcloud/dialogs'
 
 export default {
 	name: 'ProjectList',
 	components: {
 		ListItem,
-		AppContentList
+		AppContentList,
 	},
 	props: {
 		bill: {
 			type: Object,
-			required: true
+			required: true,
 		},
 		projectId: {
 			type: String,
 			required: true,
 		},
 	},
-	created() {
-	},
 	data() {
 		return {
-			cospend
+			cospend,
 		}
+	},
+	created() {
 	},
 	methods: {
 		onProjectClicked(project) {
 			network.moveBill(this.projectId, this.bill.id, project.id).then(res => {
-				showSuccess(t('cospend', 'Bill moved to "{project}" successfully', {project: project.name}))
+				showSuccess(t('cospend', 'Bill moved to "{project}" successfully', { project: project.name }))
 				this.$emit('item-moved', res.data, project.id)
 			}).catch(error => {
 				console.error(error)

--- a/src/network.js
+++ b/src/network.js
@@ -251,11 +251,11 @@ export function createBill(projectid, req) {
 	return axios.post(url, req)
 }
 
-export function moveBill (fromProjectId, billId, toProjectId) {
-	const req = {toProjectId};
-	const url = generateUrl ('/apps/cospend/projects/' + fromProjectId + '/bills/' + billId + '/move');
+export function moveBill(fromProjectId, billId, toProjectId) {
+	const req = { toProjectId }
+	const url = generateUrl('/apps/cospend/projects/' + fromProjectId + '/bills/' + billId + '/move')
 
-	return axios.post(url, req);
+	return axios.post(url, req)
 }
 
 export function generatePublicLinkToFile(targetPath) {

--- a/src/network.js
+++ b/src/network.js
@@ -251,6 +251,13 @@ export function createBill(projectid, req) {
 	return axios.post(url, req)
 }
 
+export function moveBill (fromProjectId, billId, toProjectId) {
+	const req = {toProjectId};
+	const url = generateUrl ('/apps/cospend/projects/' + fromProjectId + '/bills/' + billId + '/move');
+
+	return axios.post(url, req);
+}
+
 export function generatePublicLinkToFile(targetPath) {
 	const req = {
 		path: targetPath,


### PR DESCRIPTION
This is a rough implementation of #87:

- [x] Move basic bill information
- [x] Create payment mode on destination if it doesn't exists already
- [x] Create category on destination if it doesn't exists already
- [x] Try to match who pays and who owe it in the new project

I guess that what's left is:

- [ ] Show the move in the activity manager?
- [ ] Some more permission checks?
- [ ] Write unit tests?
- [ ] Improve design of the "move dialog"?
- [ ] Add translations for all the languages?