### PR TITLE
Drop support for Nextcloud 22, as it is EOL.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,14 +19,12 @@ jobs:
       matrix:
         php-versions: ['7.3', '7.4', '8.0', '8.1']
         databases: ['sqlite', 'mysql', 'pgsql']
-        server-versions: ['stable22', 'stable23', 'stable24', 'master']
+        server-versions: ['stable23', 'stable24', 'master']
         exclude:
           - php-versions: 7.3
             server-versions: stable24
           - php-versions: 7.3
             server-versions: master
-          - php-versions: 8.1
-            server-versions: stable22
           - php-versions: 8.1
             server-versions: stable23
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@
 	<screenshot>https://github.com/eneiluj/cospend-nc/raw/master/img/screenshots/cospend3.jpg</screenshot>
 	<screenshot>https://github.com/eneiluj/cospend-nc/raw/master/img/screenshots/cospend4.jpg</screenshot>
 	<dependencies>
-		<nextcloud min-version="22" max-version="25"/>
+		<nextcloud min-version="23" max-version="25"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\Cospend\Cron\RepeatBills</job>


### PR DESCRIPTION
Support for Nextcloud 22 ended last month (https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule)